### PR TITLE
EGR シーケンスの拡張他

### DIFF
--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/CAGRAPH.INC
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/CAGRAPH.INC
@@ -1,22 +1,40 @@
 {* CAGRAPH.INC *}
 { https://oku.edu.mie-u.ac.jp/~okumura/algo/algo_pas.html }
 
+const
+  CMaxY = 240; // Wio Terminal
+
 var
   LastX, LastY: Real;
+  UseFlip: Boolean;
+
+
+function FlipY(Y: Integer): Integer;
+begin
+  if UseFlip then
+    FlipY := CMaxY - Y
+  else
+    FlipY := Y;
+end;
+
+procedure CA_SetFlipMode(Flip: Boolean);
+begin
+  UseFlip := Flip;
+end;
 
 procedure CA_Dot(X, Y: Integer);
 begin
-  DrawPixel(x, y);
+  DrawPixel(x, FlipY(y));
 end;
 
 procedure CA_Line(X1, Y1, X2, Y2: Integer);
 begin
-  DrawLine(X1, Y1, X2, Y2);
+  DrawLine(X1, FlipY(Y1), X2, FlipY(Y2));
 end;
 
 procedure CA_Circle(Xcenter, Ycenter, Radius: Integer);
 begin
-  DrawCircle(Xcenter, Ycenter, Radius);
+  DrawCircle(Xcenter, FlipY(Ycenter), Radius);
 end;
 
 procedure CA_MoveAbsolute(X, Y: Real);
@@ -27,6 +45,7 @@ end;
 
 procedure CA_InitPlot;
 begin
+  CA_SetFlipMode(False);
   CA_MoveAbsolute(0, 0);
 end;
 

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/CAGRAPH.INC
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/CAGRAPH.INC
@@ -2,7 +2,7 @@
 { https://oku.edu.mie-u.ac.jp/~okumura/algo/algo_pas.html }
 
 const
-  CMaxY = 240; // Wio Terminal
+  CMaxY = 240;
 
 var
   LastX, LastY: Real;

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/CAGRAPH.INC
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/CAGRAPH.INC
@@ -24,7 +24,7 @@ end;
 
 procedure CA_Dot(X, Y: Integer);
 begin
-  DrawPixel(x, FlipY(y));
+  DrawPixel(X, FlipY(Y));
 end;
 
 procedure CA_Line(X1, Y1, X2, Y2: Integer);

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/EGR.INC
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/EGR.INC
@@ -116,7 +116,7 @@ const
   procedure InitGraph;
   begin
     Write(#$1B'[H'#$1B'[2J');
-    SetColor(255, 255, 255);
     SetBaseColor(0, 0, 0);
     Clear;
+    SetColor(255, 255, 255);
   end;

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/EGR.INC
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/EGR.INC
@@ -38,7 +38,12 @@ const
     Write(_EGR, x, ';', y, ';', w, 'H');
   end;
 
-  procedure DrawFastVLine(x, y, h: Integer);
+  procedure HideCursor(Flg: Boolean);
+  begin
+    Write(_EGR, Ord(Flg), 'h');
+  end;
+
+procedure DrawFastVLine(x, y, h: Integer);
   begin
     Write(_EGR, x, ';', y, ';', h, 'V');
   end;

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/EGR.INC
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/EGR.INC
@@ -1,7 +1,7 @@
 {* EGR.INC *}
 
 const
-  _EGR = #$1B'*';
+  _EGR = #$1B'%';
 
   procedure Clear;
   begin

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/GRAPH3D.PAS
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/GRAPH3D.PAS
@@ -1,0 +1,58 @@
+program GRAPH3D;
+{$I EGR.INC}
+{$I CAGRAPH.INC}
+const
+  Xmin = -1;
+  Xmax = 1;
+  Zmin = -1;
+  Zmax = 1;
+  Yscale = 100;
+var
+  X, Z: real;
+  I, Ix, Iz, Px, Py: integer;
+  Ok, LastOk: boolean;
+  LowerHorizon, UpperHorizon: array [0..240] of integer;
+
+  function Func(X, Z: real): real;
+  begin
+    Func := cos(10 * sqrt(sqr(X) + sqr(Z)))
+  end; { Func }
+
+begin
+  InitGraph;
+  CA_InitPlot;
+  SetFlipMode(True);
+  for I := 0 to 240 do
+  begin
+    LowerHorizon[I] := maxint;
+    UpperHorizon[I] := -maxint
+  end;
+  for Iz := 0 to 20 do
+  begin
+    Z := Zmin + (Zmax - Zmin) * Iz / 20;
+    LastOk := false;
+    for Ix := 0 to 200 do
+    begin
+      X := Xmin + (Xmax - Xmin) * Ix / 200;
+      I := Ix + 2 * (20 - Iz);
+      Px := 10 * I;
+      Py := round(Yscale * Func(X, Z)) + 30 * Iz + 600;
+      Ok := false;
+      if Py < LowerHorizon[I] then
+      begin
+        LowerHorizon[I] := Py;
+        Ok := true
+      end;
+      if Py > UpperHorizon[I] then
+      begin
+        UpperHorizon[I] := Py;
+        Ok := true
+      end;
+      if Ok and LastOk then
+        CA_DrawAbsolute(Px div 8, Py div 8)
+      else
+        CA_MoveAbsolute(Px div 8, Py div 8);
+      LastOk := Ok
+    end
+  end
+end.

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/GRAPH3D.PAS
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/GRAPH3D.PAS
@@ -54,5 +54,7 @@ begin
         CA_MoveAbsolute(Px div 8, Py div 8);
       LastOk := Ok
     end
-  end
+  end;
+  Readln:
+  ClrScr;
 end.

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/GRAPH3D.PAS
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/GRAPH3D.PAS
@@ -21,7 +21,7 @@ var
 begin
   InitGraph;
   CA_InitPlot;
-  SetFlipMode(True);
+  CA_SetFlipMode(True);
   for I := 0 to 240 do
   begin
     LowerHorizon[I] := maxint;

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/GRAPH3D.PAS
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/GRAPH3D.PAS
@@ -19,6 +19,7 @@ var
   end; { Func }
 
 begin
+  HideCursor(True);
   InitGraph;
   CA_InitPlot;
   CA_SetFlipMode(True);
@@ -55,6 +56,7 @@ begin
       LastOk := Ok
     end
   end;
+  HideCursor(False);
   Readln:
   ClrScr;
 end.

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/LORENZ.PAS
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/LORENZ.PAS
@@ -1,4 +1,4 @@
-program Lorenz;
+program LORENZ;
 {$I EGR.INC}
 {$I CAGRAPH.INC}
 const

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/LORENZ.PAS
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/LORENZ.PAS
@@ -11,6 +11,7 @@ var
   k: Integer;
   x, y, z, dx, dy, dz: Real;
 begin
+  HideCursor(True);  
   InitGraph;
   CA_InitPlot;
   x := 1; y := 1; z := 1;
@@ -27,6 +28,7 @@ begin
       else
         CA_MoveAbsolute((x + 30) * Scale, z * Scale);
     end;
+  HideCursor(False);  
   Readln;
   ClrScr;
 end.

--- a/Wio_RunCPM_vt100_UsbKB/TurboPascal/LORENZ.PAS
+++ b/Wio_RunCPM_vt100_UsbKB/TurboPascal/LORENZ.PAS
@@ -28,4 +28,5 @@ begin
         CA_MoveAbsolute((x + 30) * Scale, z * Scale);
     end;
   Readln;
+  ClrScr;
 end.

--- a/Wio_RunCPM_vt100_UsbKB/Wio_RunCPM_vt100_UsbKB.ino
+++ b/Wio_RunCPM_vt100_UsbKB/Wio_RunCPM_vt100_UsbKB.ino
@@ -1578,6 +1578,9 @@ void unknownSequence(em m, char c) {
       if (isDECPrivateMode)
         s = s + "?";
       break;
+    case em::EGR:
+      s = s + " %";
+      break;
   }
   DebugSerial.print(F("Unknown: "));
   DebugSerial.print(s);

--- a/Wio_RunCPM_vt100_UsbKB/Wio_RunCPM_vt100_UsbKB.ino
+++ b/Wio_RunCPM_vt100_UsbKB/Wio_RunCPM_vt100_UsbKB.ino
@@ -505,7 +505,7 @@ void printChar(char c) {
         clearParams(em::G1S);
         break;
 #ifdef USE_EGR
-      case '*':
+      case '%':
         // EGR セット シーケンス へ
         clearParams(em::EGR);
         break;
@@ -749,7 +749,7 @@ void printChar(char c) {
     return;
   }
 
-  // "*" EGR シーケンス
+  // "%" EGR シーケンス
 #ifdef USE_EGR
   if (escMode == em::EGR) {
     if (isdigit(c) || c == '-') {

--- a/Wio_RunCPM_vt100_UsbKB/Wio_RunCPM_vt100_UsbKB.ino
+++ b/Wio_RunCPM_vt100_UsbKB/Wio_RunCPM_vt100_UsbKB.ino
@@ -262,6 +262,7 @@ int16_t vals[10] = {0};
 
 // カーソル描画用
 bool needCursorUpdate = false;
+bool hideCursor = false;
 
 // 関数
 // -----------------------------------------------------------------------------
@@ -372,6 +373,8 @@ void drawCursor(uint16_t x, uint16_t y) {
 void dispCursor(bool forceupdate) {
   if (escMode != em::NONE)
     return;
+  if (hideCursor)
+    return;    
   if (!forceupdate)
     isShowCursor = !isShowCursor;
   if (isShowCursor)
@@ -807,6 +810,12 @@ void printChar(char c) {
         case 'H':
           // drawFastHLine
           lcd.drawFastHLine(vals[0], vals[1], vals[2]);
+          break;
+        case 'h':
+          // カーソル表示/非表示
+          hideCursor = (nVals != 0) && (vals[0] == 1);
+          if (hideCursor)
+            sc_updateChar(p_XP, p_YP);
           break;
         case 'K':
           // setBaseColor 

--- a/Wio_RunCPM_vt100_UsbKB/Wio_RunCPM_vt100_UsbKB.ino
+++ b/Wio_RunCPM_vt100_UsbKB/Wio_RunCPM_vt100_UsbKB.ino
@@ -1246,6 +1246,10 @@ void decSetMode(int16_t *vals, int16_t nVals) {
         // DECAWM (Auto Wrap Mode): 自動折り返しモード
         autoWrapMode(true);
         break;
+      case 25:
+        // DECTCEM (Text Cursor Enable Mode): テキストカーソル有効モード
+        hideCursor = false;
+        break;
       default:
         DebugSerial.print(F("Unimplement: decSetMode "));
         DebugSerial.println(String(vals[i], DEC));
@@ -1281,6 +1285,11 @@ void decResetMode(int16_t *vals, int16_t nVals) {
       case 7:
         // DECAWM (Auto Wrap Mode): 自動折り返しモード
         autoWrapMode(false);
+        break;
+      case 25:
+        // DECTCEM (Text Cursor Enable Mode): テキストカーソル有効モード
+        hideCursor = true;
+        sc_updateChar(p_XP, p_YP);
         break;
       default:
         DebugSerial.print(F("Unimplement: decResetMode "));

--- a/Wio_RunCPM_vt100_UsbKB/abstraction_arduino.h
+++ b/Wio_RunCPM_vt100_UsbKB/abstraction_arduino.h
@@ -530,7 +530,7 @@ void _putch(uint8 ch) {
 
 void _clrscr(void) {
 //	Serial.println("\e[H\e[J");
-  printString("\e[H\e[J");
+  printString("\e[H\e[2J");
 }
 
 #endif


### PR DESCRIPTION
 - CLS コマンドでマージン領域がクリアされないため、_clrscr() の処理を変更。
 - EGR シーケンスのパラメータにマイナスの値を指定できるようにした。
 - EGR シーケンスの開始文字を変更 ('\*' -> '%')。'\*' は文字集合の指示に使われていた。
 - HideCursor EGR シーケンスを追加。グラフィック描画時にカーソルを消せるようにした。
 - DECTCEM (Text Cursor Enable Mode) を追加。こちらでもカーソルをオンオフ可能。
 - 上記変更に伴い、Turbo Pascal 関連ファイルも修正。